### PR TITLE
fix: add Y axis position calculation for nestedPosition method

### DIFF
--- a/packages/utils/src/dom/methods/nestedPosition.ts
+++ b/packages/utils/src/dom/methods/nestedPosition.ts
@@ -1,6 +1,8 @@
 import calculateScrollbarWidth from './calculateScrollbarWidth';
+import getHiddenElementOuterHeight from './getHiddenElementOuterHeight';
 import getHiddenElementOuterWidth from './getHiddenElementOuterWidth';
 import getOffset from './getOffset';
+import getOuterHeight from './getOuterHeight';
 import getOuterWidth from './getOuterWidth';
 import getViewport from './getViewport';
 
@@ -11,7 +13,14 @@ export default function nestedPosition(element: HTMLElement, level: number): voi
         const viewport = getViewport();
         const sublistWidth = element.offsetParent ? element.offsetWidth : getHiddenElementOuterWidth(element);
         const itemOuterWidth = getOuterWidth(parentItem?.children?.[0]);
+
+        const sublistHeight = element.offsetParent
+            ? element.offsetHeight
+            : getHiddenElementOuterHeight(element);
+        const itemOuterHeight = getOuterHeight(parentItem?.children?.[0] as HTMLElement);
+
         let left: string = '';
+        let top: string = '';
 
         if ((elementOffset.left as number) + itemOuterWidth + sublistWidth > viewport.width - calculateScrollbarWidth()) {
             if ((elementOffset.left as number) < sublistWidth) {
@@ -28,7 +37,14 @@ export default function nestedPosition(element: HTMLElement, level: number): voi
             left = '100%';
         }
 
-        element.style.top = '0px';
+        // getBoundingClientRect returns a top position from the current visible viewport area
+        if (element.getBoundingClientRect().top + itemOuterHeight + sublistHeight > viewport.height) {
+            top = `-${sublistHeight - itemOuterHeight}px`;
+        } else {
+            top = "0px";
+        }
+
+        element.style.top = top;
         element.style.left = left;
     }
 }


### PR DESCRIPTION
This is for Primevue's issue of `ContextMenu`.
https://github.com/primefaces/primevue/issues/6348
In these changes I add the Y axis position calculation, so this can be useful for `ContextMenu` sub items. The follow video show how position of elements is changing in the end of visible area.
![Vue ContextMenu Component - Google Chrome 2024-10-27 11-47-24](https://github.com/user-attachments/assets/e425cf57-8839-42d1-b120-48f5a4a2caf0)
