### PR TITLE
Fix: Add Floatlabel placeholder handling [primefaces/primevue#7102]

### DIFF
--- a/packages/styles/src/floatlabel/index.ts
+++ b/packages/styles/src/floatlabel/index.ts
@@ -39,7 +39,9 @@ export const style: StyleType = ({ dt }) => `
 .p-floatlabel:has(textarea:focus) label,
 .p-floatlabel:has(textarea.p-filled) label,
 .p-floatlabel:has(.p-inputwrapper-focus) label,
-.p-floatlabel:has(.p-inputwrapper-filled) label {
+.p-floatlabel:has(.p-inputwrapper-filled) label,
+.p-floatlabel:has(input[placeholder]) label,
+.p-floatlabel:has(textarea[placeholder]) label {
     top: ${dt('floatlabel.over.active.top')};
     transform: translateY(0);
     font-size: ${dt('floatlabel.active.font.size')};
@@ -76,7 +78,9 @@ export const style: StyleType = ({ dt }) => `
 .p-floatlabel-in:has(textarea:focus) label,
 .p-floatlabel-in:has(textarea.p-filled) label,
 .p-floatlabel-in:has(.p-inputwrapper-focus) label,
-.p-floatlabel-in:has(.p-inputwrapper-filled) label {
+.p-floatlabel-in:has(.p-inputwrapper-filled) label,
+.p-floatlabel-in:has(input[placeholder]) label,
+.p-floatlabel-in:has(textarea[placeholder]) label {
     top: ${dt('floatlabel.in.active.top')};
 }
 
@@ -86,7 +90,9 @@ export const style: StyleType = ({ dt }) => `
 .p-floatlabel-on:has(textarea:focus) label,
 .p-floatlabel-on:has(textarea.p-filled) label,
 .p-floatlabel-on:has(.p-inputwrapper-focus) label,
-.p-floatlabel-on:has(.p-inputwrapper-filled) label {
+.p-floatlabel-on:has(.p-inputwrapper-filled) label,
+.p-floatlabel-on:has(input[placeholder]) label,
+.p-floatlabel-on:has(textarea[placeholder]) label {
     top: 0;
     transform: translateY(-50%);
     border-radius: ${dt('floatlabel.on.border.radius')};


### PR DESCRIPTION
Fixes issue https://github.com/primefaces/primevue/issues/7102

I hope I found the correct place to add placeholder handling for Floatlabels.

And also hope that you like the changes, even though you replied in the issue that this would be out of scope.

In my opinion this is rather a bugfix than a feature request, since Floatlabels do not forbid the usage of placeholders
and for consistency reasons one would require to omit Floatlabels completely as soon as only one Input field uses a placeholder.

From a barrier-free usage perspective it might also be critical to rely on placeholders that differ from the label. 

I hope you like it!