### PR TITLE
Add attribute activeHoverColor to AccordionTokenSections.Header.

### DIFF
--- a/packages/themes/src/types/accordion/index.d.ts
+++ b/packages/themes/src/types/accordion/index.d.ts
@@ -56,6 +56,12 @@ export declare namespace AccordionTokenSections {
          */
         activeColor?: string;
         /**
+         * Active hover color of header
+         *
+         * @designToken accordion.header.active.hover.color
+         */
+        activeHoverColor?: string;
+        /**
          * Padding of header
          *
          * @designToken accordion.header.padding


### PR DESCRIPTION
This fixes bug [https://github.com/primefaces/primeuix/issues/61](https://github.com/primefaces/primeuix/issues/61), which is a duplicate of [https://github.com/primefaces/primevue/issues/5999](https://github.com/primefaces/primevue/issues/5999).

The change adds the missing attribute `activeHoverColor?` in `AccordionDesignTokens.Header`.