### PR TITLE
fix(floatlabel): overriden "invalid" style

### DIFF
--- a/packages/styles/src/floatlabel/index.ts
+++ b/packages/styles/src/floatlabel/index.ts
@@ -30,7 +30,7 @@ export const style: StyleType = ({ dt }) => `
 }
 
 .p-floatlabel:has(.p-invalid) label {
-    color: ${dt('floatlabel.invalid.color')};
+    color: ${dt('floatlabel.invalid.color')} !important;
 }
 
 .p-floatlabel:has(input:focus) label,


### PR DESCRIPTION
[#7572 PrimeVue](https://github.com/primefaces/primevue/issues/7572#issue-2971392795)