### PR TITLE
fix(tabs): allow disabled tab to display tooltips

### DIFF
--- a/packages/styles/src/tabs/index.ts
+++ b/packages/styles/src/tabs/index.ts
@@ -102,6 +102,11 @@ export const style: StyleType = ({ dt }) => `
     outline-color: transparent;
 }
 
+.p-tab.p-disabled {
+    pointer-events: auto;
+    cursor: default;
+}
+
 .p-tab:not(.p-disabled):focus-visible {
     z-index: 1;
     box-shadow: ${dt('tabs.tab.focus.ring.shadow')};


### PR DESCRIPTION
[#7668 PrimeVue](https://github.com/primefaces/primevue/issues/7668)