### PR TITLE
refactor(css): remove dynamic function construction to support strict CSP

### DIFF
--- a/packages/styled/src/helpers/css.ts
+++ b/packages/styled/src/helpers/css.ts
@@ -2,20 +2,23 @@ import { resolve } from '@primeuix/utils';
 import { type StyleType, transformDtToInterpolated } from '..';
 import { dt } from './dt';
 
-const INTERPOLATION_REGEX = /\$\{dt\.([a-zA-Z0-9_.]+)\}/g;
+const FUNCTION_CALL_REGEX = /dt\(\s*['"`]([^'"`]+)['"`]\s*\)/g;
 
 export function css(strings: TemplateStringsArray | StyleType, ...exprs: unknown[]): string | undefined {
-    if (Array.isArray(strings)) {
-        const raw = strings.reduce((acc, str, i) => acc + str + (resolve(exprs[i], { dt }) ?? ''), '');
-        let interpolated = transformDtToInterpolated(raw);
+  if (Array.isArray(strings)) {
+    // Interpolate expressions into the template
+    let raw = strings.reduce((acc, str, i) => acc + str + (resolve(exprs[i], { dt }) ?? ''), '');
 
-        interpolated = interpolated.replace(INTERPOLATION_REGEX, (_, path) => {
-            const value = resolve(path, { dt });
-            return value != null ? String(value) : '';
-        });
+    let interpolated = transformDtToInterpolated(raw);
 
-        return interpolated;
-    }
+    // Replace dt('foo.bar') with resolved value
+    interpolated = interpolated.replace(FUNCTION_CALL_REGEX, (_, path) => {
+      const value = resolve(path, { dt });
+      return value != null ? String(value) : '';
+    });
 
-    return resolve(strings as unknown, { dt }) as string | undefined;
+    return interpolated;
+  }
+
+  return resolve(strings as unknown, { dt }) as string | undefined;
 }

--- a/packages/styled/src/helpers/css.ts
+++ b/packages/styled/src/helpers/css.ts
@@ -2,14 +2,19 @@ import { resolve } from '@primeuix/utils';
 import { type StyleType, transformDtToInterpolated } from '..';
 import { dt } from './dt';
 
+const INTERPOLATION_REGEX = /\$\{dt\.([a-zA-Z0-9_.]+)\}/g;
+
 export function css(strings: TemplateStringsArray | StyleType, ...exprs: unknown[]): string | undefined {
-    if (strings instanceof Array) {
+    if (Array.isArray(strings)) {
         const raw = strings.reduce((acc, str, i) => acc + str + (resolve(exprs[i], { dt }) ?? ''), '');
-        const interpolated = transformDtToInterpolated(raw);
+        let interpolated = transformDtToInterpolated(raw);
 
-        const compile = new Function('{ dt }', `return \`${interpolated}\`;`);
+        interpolated = interpolated.replace(INTERPOLATION_REGEX, (_, path) => {
+            const value = resolve(path, { dt });
+            return value != null ? String(value) : '';
+        });
 
-        return compile({ dt }) as string | undefined;
+        return interpolated;
     }
 
     return resolve(strings as unknown, { dt }) as string | undefined;


### PR DESCRIPTION
This refactors the css utility to eliminate the use of new Function(), which previously required 'unsafe-eval' in the Content-Security-Policy header.

resolves comments in #75 