### PR TITLE
fix: quill placeholder color

### DIFF
--- a/packages/styles/src/editor/index.ts
+++ b/packages/styles/src/editor/index.ts
@@ -282,7 +282,7 @@ export const style: StyleType = ({ dt }) => `
     text-align: right;
 }
 .ql-editor.ql-blank::before {
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--p-form-field-placeholder-color);
     content: attr(data-placeholder);
     font-style: italic;
     inset-inline-start: 15px;


### PR DESCRIPTION
Fix https://github.com/primefaces/primevue/issues/7705

`color: rgba(0, 0, 0, 0.6);` is not correct, this fix is to use defined variable color.