### PR TITLE
Update zodResolver

### DIFF
--- a/packages/forms/src/resolvers/zod/index.ts
+++ b/packages/forms/src/resolvers/zod/index.ts
@@ -16,10 +16,10 @@ export const zodResolver =
                 errors: {}
             };
         } catch (e: any) {
-            if (Array.isArray(e?.errors)) {
+            if (Array.isArray(e?.issues)) {
                 return {
                     values: toValues(raw ? values : undefined, name),
-                    errors: e.errors.reduce((acc: Record<string, any[]>, error: any) => {
+                    errors: e.issues.reduce((acc: Record<string, any[]>, error: any) => {
                         const pathKey = isNotEmpty(error.path) ? error.path.join('.') : name;
 
                         if (pathKey) {


### PR DESCRIPTION
When using the latest version of zod (>3.25.0)；
import {zod} from 'zod/v4'；
use 'issues' instead of 'errors' for validation errors