### PR TITLE
Fix Preset<T = object> = BaseDesignToken<...> decl leading to Angular compile error

### DIFF
--- a/packages/themes/types/index.d.ts
+++ b/packages/themes/types/index.d.ts
@@ -228,7 +228,7 @@ export declare type BaseDesignTokens<T extends Partial<{ primitive: unknown; sem
     semantic?: T extends { semantic?: infer S } ? S : undefined;
 };
 
-export declare type Preset<T = object> = BaseDesignTokens<T> & {
+export declare type Preset<T = object> = BaseDesignTokens<T extends Partial<{ primitive: unknown; semantic: unknown }> ? T : never> & {
     components?: ComponentsDesignTokens;
     extend?: ExtendedTokens;
     css?: ExtendedCSS;


### PR DESCRIPTION
Issue: https://github.com/primefaces/primeuix/issues/99

This PR fixes the issue by extending

```typescript
export declare type Preset<T = object> = BaseDesignTokens<T> & {
```

with

```typescript
export declare type Preset<T = object> = BaseDesignTokens<T extends Partial<{ primitive: unknown; semantic: unknown }> ? T : never> & {
```

The compile error disappears then.