### PR TITLE
fix: add missing background tokens to lara tabs theme, Fixes #103

### DIFF
--- a/packages/themes/src/presets/lara/tabs/index.ts
+++ b/packages/themes/src/presets/lara/tabs/index.ts
@@ -11,6 +11,9 @@ export const tablist: TabsTokenSections.Tablist = {
 };
 
 export const tab: TabsTokenSections.Tab = {
+    background: '{surface.50}',
+    hoverBackground: '{surface.100}',
+    activeBackground: '{surface.0}',
     borderWidth: '2px 0 0 0',
     borderColor: 'transparent',
     hoverBorderColor: 'transparent',


### PR DESCRIPTION
Adds missing `background`, `hoverBackground`, and `activeBackground` tokens to the Lara Tabs.

These tokens were only defined under `colorScheme`, so overrides like this didn’t work:

```ts
components: {
  tabs: {
    tab: {
      background: 'red',
      activeBackground: 'red',
      hoverBackground: 'red',
    }
  }
}
```

This change adds them at the top level with values to match the current Lara look from [primevue.org](https://primevue.org/), and allows token use other themes like Aura, Nora, and Material.

Fixes #103