### PR TITLE
Fix invalid CSS selector for focusable links detection

### DIFF
--- a/packages/utils/src/dom/methods/getFocusableElements.ts
+++ b/packages/utils/src/dom/methods/getFocusableElements.ts
@@ -4,7 +4,7 @@ export default function getFocusableElements(element: Element, selector: string 
     const focusableElements = find(
         element,
         `button:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${selector},
-            [href][clientHeight][clientWidth]:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${selector},
+            [href]:not([tabindex = "-1"]):not([style*="display:none"]):not([hidden])${selector},
             input:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${selector},
             select:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${selector},
             textarea:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${selector},


### PR DESCRIPTION
Replace invalid [clientHeight][clientWidth] attribute selectors with proper element selectors for <a> and <area> tags. The previous selector used JavaScript properties as CSS attributes, which is invalid syntax and prevented proper focusable element detection.

- Replace [href][clientHeight][clientWidth] with [href]
- Remove invalid [disabled] attribute for anchor elements

Fixes #111
