### PR TITLE
fix: menu ripple leak outside o item border radius, Fixes #119

### DIFF
--- a/packages/styles/src/menu/index.ts
+++ b/packages/styles/src/menu/index.ts
@@ -23,6 +23,7 @@ export const style = /*css*/ `
             color dt('menu.transition.duration');
         border-radius: dt('menu.item.border.radius');
         color: dt('menu.item.color');
+        overflow: hidden;
     }
 
     .p-menu-item-link {


### PR DESCRIPTION
Fixes : #<#119>. and [primefaces/primeng/#18008](https://github.com/primefaces/primeng/issues/18008)

 **Before :** 
<img width="477" height="260" alt="menu-ripple-before" src="https://github.com/user-attachments/assets/089b9d16-91af-419e-9bd4-82e51915c32c" />

**After :**
<img width="477" height="260" alt="menu-ripple-after" src="https://github.com/user-attachments/assets/2827fea2-b652-4943-a133-d80551c41dcd" />
