### PR TITLE
fix: primeng 18735 & 18693 - Remove absolute positioning for clear icon

### DIFF
--- a/packages/styles/src/select/index.ts
+++ b/packages/styles/src/select/index.ts
@@ -50,9 +50,7 @@ export const style = /*css*/ `
     }
 
     .p-select-clear-icon {
-        position: absolute;
-        top: 50%;
-        margin-top: -0.5rem;
+        align-self: center;
         color: dt('select.clear.icon.color');
         inset-inline-end: dt('select.dropdown.width');
     }
@@ -94,7 +92,7 @@ export const style = /*css*/ `
     }
 
     .p-select:has(.p-select-clear-icon) .p-select-label {
-        padding-inline-end: calc(1rem + dt('select.padding.x'));
+        padding-inline-end: dt('select.padding.x');
     }
 
     .p-select.p-disabled .p-select-label {

--- a/packages/styles/src/treeselect/index.ts
+++ b/packages/styles/src/treeselect/index.ts
@@ -50,9 +50,7 @@ export const style = /*css*/ `
     }
 
     .p-treeselect-clear-icon {
-        position: absolute;
-        top: 50%;
-        margin-top: -0.5rem;
+        align-self: center;
         color: dt('treeselect.clear.icon.color');
         inset-inline-end: dt('treeselect.dropdown.width');
     }
@@ -93,6 +91,10 @@ export const style = /*css*/ `
 
     .p-treeselect.p-invalid .p-treeselect-label.p-placeholder {
         color: dt('treeselect.invalid.placeholder.color');
+    }
+
+    .p-treeselect:has(.p-select-clear-icon) .p-treeselect-label {
+        padding-inline-end: dt('treeselect.padding.x');
     }
 
     .p-treeselect.p-disabled .p-treeselect-label {


### PR DESCRIPTION
Removing the absolute positioning for the clear icon for the tree select component. Switching to flexbox align-self to ensure the icon appears in the middle.

Fixes [#18735](https://github.com/primefaces/primeng/issues/18735) & [#18693](https://github.com/primefaces/primeng/issues/18693)