### PR TITLE
feat(Button): Adding default font size for button based for new value…

### DIFF
--- a/packages/styles/src/button/index.ts
+++ b/packages/styles/src/button/index.ts
@@ -11,7 +11,7 @@ export const style = /*css*/ `
         background: dt('button.primary.background');
         border: 1px solid dt('button.primary.border.color');
         padding: dt('button.padding.y') dt('button.padding.x');
-        font-size: 1rem;
+        font-size: dt('button.font.size', '1rem');
         font-family: inherit;
         font-feature-settings: inherit;
         transition:

--- a/packages/themes/src/presets/aura/base/index.d.ts
+++ b/packages/themes/src/presets/aura/base/index.d.ts
@@ -60,6 +60,7 @@ export declare namespace AuraBaseTokenSections {
         formField?: {
             paddingX?: string;
             paddingY?: string;
+            fontSize?: string;
             sm?: {
                 fontSize?: string;
                 paddingX?: string;

--- a/packages/themes/src/presets/aura/base/index.ts
+++ b/packages/themes/src/presets/aura/base/index.ts
@@ -61,6 +61,7 @@ export const semantic: AuraBaseTokenSections.Semantic = {
     formField: {
         paddingX: '0.75rem',
         paddingY: '0.5rem',
+        fontSize: '1rem',
         sm: {
             fontSize: '0.875rem',
             paddingX: '0.625rem',

--- a/packages/themes/src/presets/lara/base/index.d.ts
+++ b/packages/themes/src/presets/lara/base/index.d.ts
@@ -59,6 +59,7 @@ export declare namespace LaraBaseTokenSections {
         formField?: {
             paddingX?: string;
             paddingY?: string;
+            fontSize?: string;
             sm?: {
                 fontSize?: string;
                 paddingX?: string;

--- a/packages/themes/src/presets/lara/base/index.ts
+++ b/packages/themes/src/presets/lara/base/index.ts
@@ -60,6 +60,7 @@ export const semantic: LaraBaseTokenSections.Semantic = {
     formField: {
         paddingX: '0.75rem',
         paddingY: '0.625rem',
+        fontSize: '1rem',
         sm: {
             fontSize: '0.875rem',
             paddingX: '0.625rem',

--- a/packages/themes/src/presets/lara/button/index.ts
+++ b/packages/themes/src/presets/lara/button/index.ts
@@ -7,6 +7,7 @@ export const root: ButtonTokenSections.Root = {
     paddingX: '1rem',
     paddingY: '{form.field.padding.y}',
     iconOnlyWidth: '2.75rem',
+    fontSize: '{form.field.font.size}',
     sm: {
         fontSize: '{form.field.sm.font.size}',
         paddingX: '{form.field.sm.padding.x}',

--- a/packages/themes/src/presets/material/base/index.d.ts
+++ b/packages/themes/src/presets/material/base/index.d.ts
@@ -59,6 +59,7 @@ export declare namespace MaterialBaseTokenSections {
         formField?: {
             paddingX?: string;
             paddingY?: string;
+            fontSize?: string;
             sm?: {
                 fontSize?: string;
                 paddingX?: string;

--- a/packages/themes/src/presets/material/base/index.ts
+++ b/packages/themes/src/presets/material/base/index.ts
@@ -60,6 +60,7 @@ export const semantic: MaterialBaseTokenSections.Semantic = {
     formField: {
         paddingX: '0.75rem',
         paddingY: '0.75rem',
+        fontSize: '1rem',
         sm: {
             fontSize: '0.875rem',
             paddingX: '0.625rem',

--- a/packages/themes/src/presets/material/button/index.ts
+++ b/packages/themes/src/presets/material/button/index.ts
@@ -7,6 +7,7 @@ export const root: ButtonTokenSections.Root = {
     paddingX: '1rem',
     paddingY: '0.625rem',
     iconOnlyWidth: '3rem',
+    fontSize: '{form.field.font.size}',
     sm: {
         fontSize: '{form.field.sm.font.size}',
         paddingX: '{form.field.sm.padding.x}',

--- a/packages/themes/src/presets/nora/base/index.d.ts
+++ b/packages/themes/src/presets/nora/base/index.d.ts
@@ -60,6 +60,7 @@ export declare namespace NoraBaseTokenSections {
         formField?: {
             paddingX?: string;
             paddingY?: string;
+            fontSize?: string;
             sm?: {
                 fontSize?: string;
                 paddingX?: string;

--- a/packages/themes/src/presets/nora/base/index.ts
+++ b/packages/themes/src/presets/nora/base/index.ts
@@ -61,6 +61,7 @@ export const semantic: NoraBaseTokenSections.Semantic = {
     formField: {
         paddingX: '0.75rem',
         paddingY: '0.5rem',
+        fontSize: '1rem',
         sm: {
             fontSize: '0.875rem',
             paddingX: '0.625rem',

--- a/packages/themes/src/presets/nora/button/index.ts
+++ b/packages/themes/src/presets/nora/button/index.ts
@@ -7,6 +7,7 @@ export const root: ButtonTokenSections.Root = {
     paddingX: '{form.field.padding.x}',
     paddingY: '{form.field.padding.y}',
     iconOnlyWidth: '2.5rem',
+    fontSize: '{form.field.font.size}',
     sm: {
         fontSize: '{form.field.sm.font.size}',
         paddingX: '{form.field.sm.padding.x}',

--- a/packages/themes/types/button/index.d.ts
+++ b/packages/themes/types/button/index.d.ts
@@ -50,6 +50,12 @@ export declare namespace ButtonTokenSections {
          */
         iconOnlyWidth?: string;
         /**
+         * Font size of root
+         *
+         * @designToken button.font.size
+         */
+        fontSize?: string;
+        /**
          * Sm of root
          */
         sm?: {
@@ -78,6 +84,7 @@ export declare namespace ButtonTokenSections {
              */
             iconOnlyWidth?: string;
         };
+
         /**
          * Lg of root
          */


### PR DESCRIPTION
Adding design token value for default font size on buttons and defaulting to 1rem to be backward compatible.

Since sm and lg buttons get their theme sizes from form field I also add this for the default font size. If you prefer to just add for button and not touch base file for themes i can change to that.

Fixes #133 