### PR TITLE
Fix cursor for disabled datepicker

### DIFF
--- a/packages/styles/src/datepicker/index.ts
+++ b/packages/styles/src/datepicker/index.ts
@@ -48,7 +48,11 @@ export const style = /*css*/ `
         border-color: dt('datepicker.dropdown.active.border.color');
         color: dt('datepicker.dropdown.active.color');
     }
-
+    
+    .p-datepicker-dropdown:disabled {
+        cursor: default;
+    }
+    
     .p-datepicker-dropdown:focus-visible {
         box-shadow: dt('datepicker.dropdown.focus.ring.shadow');
         outline: dt('datepicker.dropdown.focus.ring.width') dt('datepicker.dropdown.focus.ring.style') dt('datepicker.dropdown.focus.ring.color');


### PR DESCRIPTION
When the datepicker is used with showIcon and disabled, the cursor is a pointer. But it really should be using the default cursor

**Before**
<img width="210" height="70" alt="pickericon-before" src="https://github.com/user-attachments/assets/e258ed75-c323-45de-aee3-7dc55a356d14" />

**After**
<img width="210" height="70" alt="pickericon-after" src="https://github.com/user-attachments/assets/8316c594-0182-4792-8e6d-6b54636c83ed" />

Fixes primefaces/primevue#6576