### PR TITLE
Do not apply floatlabel inputtext styles to select filter

### DIFF
--- a/packages/styles/src/floatlabel/index.ts
+++ b/packages/styles/src/floatlabel/index.ts
@@ -55,7 +55,7 @@ export const style = /*css*/ `
         color: dt('floatlabel.focus.color');
     }
 
-    .p-floatlabel-in .p-inputtext,
+    .p-floatlabel-in .p-inputtext:not(.p-select-filter),
     .p-floatlabel-in .p-textarea,
     .p-floatlabel-in .p-select-label,
     .p-floatlabel-in .p-multiselect-label,


### PR DESCRIPTION
Before:
<img width="416" height="584" alt="image" src="https://github.com/user-attachments/assets/830839bf-071c-431a-b67c-8cb62597020b" />

After:
<img width="414" height="556" alt="image" src="https://github.com/user-attachments/assets/42dc60a5-75a9-4c24-afed-575da791dce7" />

closes primefaces/primeng#18892