### PR TITLE
style(image): add focus state to preview mask selector

### DIFF
--- a/packages/styles/src/image/index.ts
+++ b/packages/styles/src/image/index.ts
@@ -30,7 +30,8 @@ export const style = /*css*/ `
         transition: background dt('image.transition.duration');
     }
 
-    .p-image-preview:hover > .p-image-preview-mask {
+    .p-image-preview:hover > .p-image-preview-mask,
+    .p-image-preview-mask:focus-visible {
         opacity: 1;
         cursor: pointer;
         background: dt('image.preview.mask.background');


### PR DESCRIPTION
I want the `image-preview-mask`(button) to show when it is focused.