### PR TITLE
fix: use ordered list for Timeline component to improve accessibility

### DIFF
--- a/packages/styles/src/timeline/index.ts
+++ b/packages/styles/src/timeline/index.ts
@@ -4,6 +4,9 @@ export const style = /*css*/ `
         flex-grow: 1;
         flex-direction: column;
         direction: ltr;
+        list-style: none;
+        margin: 0;
+        padding: 0;
     }
 
     .p-timeline-left .p-timeline-event-opposite {


### PR DESCRIPTION
### Defect Fixes
According to the Timeline documentation: "Timeline uses a semantic ordered list element to list the events.", but that's not the case, Timeline is using div tags without any semantic meaning.

This PR is adding necessary rules to disable default styling of ol and li tags added to the Timeline component in following PR: https://github.com/primefaces/primevue/pull/8155