### PR TITLE
Bugfix: Prevent nested splitter from uncontrolled resizing

### DIFF
--- a/packages/styles/src/splitter/index.ts
+++ b/packages/styles/src/splitter/index.ts
@@ -76,6 +76,8 @@ export const style = /*css*/ `
 
     .p-splitterpanel .p-splitter {
         flex-grow: 1;
+        min-width: 0;
+        min-height: 0;
         border: 0 none;
     }
 `;


### PR DESCRIPTION
When using nested Splitter components in PrimeVue, if the content within a leaf SplitterPanel (a panel containing actual content rather than another Splitter component) exceeds the panel's allocated dimensions, the Splitter expands beyond the size constraints imposed by its parent SplitterPanel, breaking the intended layout.

This issue is related to the well-documented CSS flexbox behavior where flex items have an implicit min-width: auto

Fix #160
