### PR TITLE
ButtonGroup Mixed Button Height Adjustment

### DIFF
--- a/packages/styles/src/buttongroup/index.ts
+++ b/packages/styles/src/buttongroup/index.ts
@@ -5,6 +5,7 @@ export const style = /*css*/ `
 
     .p-buttongroup .p-button {
         margin: 0;
+        height: 100%;
     }
 
     .p-buttongroup .p-button:not(:last-child),


### PR DESCRIPTION
closes primefaces/primeng#18991

Before:
<img width="282" height="274" alt="image" src="https://github.com/user-attachments/assets/3063a249-1028-4f3b-a52b-75cce615a1ba" />

After:
<img width="282" height="276" alt="image" src="https://github.com/user-attachments/assets/88bdee1e-98ce-4eef-8cb2-ade9510e7101" />
