### PR TITLE
fix: missing styling for .p-dialog-content #183

### DIFF
--- a/packages/styles/src/dialog/index.ts
+++ b/packages/styles/src/dialog/index.ts
@@ -12,6 +12,7 @@ export const style = /*css*/ `
     .p-dialog-content {
         overflow-y: auto;
         padding: dt('dialog.content.padding');
+        flex-grow: 1;
     }
 
     .p-dialog-header {


### PR DESCRIPTION
The class `.p-dialog-content` is missing the styling `flex-grow: 1;`. Which causes that virtual scrolling with flex height within a dialog not to work.

closes #183