### PR TITLE
188: Rename chip.icon.font.size to chip.icon.size

### DIFF
--- a/packages/styles/src/chip/index.ts
+++ b/packages/styles/src/chip/index.ts
@@ -12,7 +12,7 @@ export const style = /*css*/ `
 
     .p-chip-icon {
         color: dt('chip.icon.color');
-        font-size: dt('chip.icon.font.size');
+        font-size: dt('chip.icon.size');
         width: dt('chip.icon.size');
         height: dt('chip.icon.size');
     }


### PR DESCRIPTION
### Defect Fixes
This PR fixes https://github.com/primefaces/primeuix/issues/188 (wrong design token used in chip)
