### PR TITLE
fix: unused zIndexes on element update

### DIFF
--- a/packages/utils/src/zindex/index.ts
+++ b/packages/utils/src/zindex/index.ts
@@ -37,6 +37,7 @@ function handler(): ZIndexOptions {
         get: getZIndex,
         set: (key: string, element?: HTMLElement, baseZIndex?: number) => {
             if (element) {
+                revertZIndex(getZIndex(element));
                 element.style.zIndex = String(generateZIndex(key, true, baseZIndex));
             }
         },


### PR DESCRIPTION
Fixes https://github.com/primefaces/primevue/issues/8393

If an element, which wants to `set` a new zIndex, I see no reason to not remove it from the `zIndexes`. This behavior makes sense for example in the PrimeVue toast component, as it should increase its zIndex if new messages get added (move in front of a dialog, if the dialog triggers toast messages while open), but not leave any unused ones behind in the `zIndexes`.