### PR TITLE
fix(forms): fix Zod v4 compatibility in zodResolver type declaration

### DIFF
--- a/packages/forms/src/resolvers/zod/index.ts
+++ b/packages/forms/src/resolvers/zod/index.ts
@@ -1,10 +1,10 @@
 import { toValues } from '@primeuix/forms/utils';
 import { isNotEmpty } from '@primeuix/utils';
-import type { ParseParams, Schema } from 'zod';
+import type { Schema } from 'zod';
 import type { ResolverOptions, ResolverResult } from '..';
 
 export const zodResolver =
-    <T extends Schema<any, any>>(schema: T, schemaOptions?: ParseParams, resolverOptions?: ResolverOptions) =>
+    <T extends Schema<any, any>>(schema: T, schemaOptions?: Parameters<T['parse']>[1], resolverOptions?: ResolverOptions) =>
     async ({ values, name }: any): Promise<ResolverResult<T>> => {
         const { sync = false, raw = false } = resolverOptions || {};
 


### PR DESCRIPTION
### Defect Fixes

Fixes #219

The `zodResolver` type declaration imports `ParseParams` from `zod`, which was removed in Zod v4. This causes `TS2305: Module '"zod"' has no exported member 'ParseParams'` for projects using Zod v4 with `skipLibCheck: false`.

### Change

Replace `ParseParams` with `Parameters<T['parse']>[1]`, which uses TypeScript's built-in `Parameters` utility to infer the second argument type of the schema's `parse()` method. This automatically resolves to:

- **Zod v3**: `InexactPartial<ParseParams>` (= `{ path?, errorMap?, async? }`)
- **Zod v4**: `ParseContext<$ZodIssue>` (= `{ error?, reportInput?, jitless? }`)

The approach is forward-compatible with any future Zod version — no maintenance burden.

### Impact

- **Runtime**: Zero — types only, the `.mjs` bundle is unchanged
- **Zod v3 users**: No breaking change — same inferred type as before
- **Zod v4 users**: Fixes the broken import, provides correct `ParseContext` autocomplete

Related: #33, #187