### PR TITLE
fix(mcp): convert custom tool parameters to Zod schemas for MCP SDK c…

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -26,6 +26,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
 
 import { registerComponentTools, registerExampleTools, registerGuideTools, registerSearchTools } from './tools/index.js';
 import type { ComponentsData, CustomToolDefinition, PrimeMcpConfig, ToolResult } from './types.js';
@@ -82,17 +83,14 @@ export async function createPrimeMcpServer(config: PrimeMcpConfig): Promise<McpS
  */
 function registerCustomTools(server: McpServer, data: ComponentsData, customTools: CustomToolDefinition[]): void {
     for (const tool of customTools) {
-        // Convert our parameter format to MCP's expected format
-        const params: Record<string, { type: string; description: string }> = {};
+        const fields: Record<string, z.ZodTypeAny> = {};
 
         for (const [key, value] of Object.entries(tool.parameters)) {
-            params[key] = {
-                type: value.type,
-                description: value.description
-            };
+            const baseType = z.string().describe(value.description);
+            fields[key] = value.required ? baseType : baseType.optional();
         }
 
-        server.tool(tool.name, tool.description, params, async (args) => {
+        server.tool(tool.name, tool.description, fields, async (args) => {
             const result = await tool.handler(data, args as Record<string, unknown>);
 
             return result as ToolResult & { [x: string]: unknown };

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -115,7 +115,10 @@ export interface CustomToolDefinition {
     parameters: Record<
         string,
         {
-            type: string;
+            // Only 'string' is supported for now, as all current custom tool parameters across
+            // PrimeNG and PrimeVue use string values. If a new type is needed, extend this union
+            // and add the corresponding Zod mapping in the registerCustomTools function in index.ts.
+            type: 'string';
             description: string;
             required?: boolean;
             default?: unknown;


### PR DESCRIPTION
  Fixes primefaces/primeng#19504

  ## Problem
  The `@modelcontextprotocol/sdk` v1.29.0 updated its `McpServer.tool()` API to require
  Zod schemas instead of plain objects for tool parameters. This caused the MCP
  server to fail on startup with:

  Tool get_migration_guide expected a Zod schema or ToolAnnotations,
  but received an unrecognized object

  ## Solution
  - Updated `registerCustomTools` to build Zod schemas from the `parameters`
    definition before registering each tool
  - Restricted `CustomToolDefinition.parameters.type` to `'string'` (the only
    type currently used across PrimeNG and PrimeVue). To add support for other
    types, extend the union in `types.ts` accordingly

  ## Breaking change
  None — consumers of `runPrimeMcpServer` do not need to change their custom tool definitions.
