### PR TITLE
fix(mcp): register custom tools with a Zod input schema

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -26,6 +26,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
 
 import { registerComponentTools, registerExampleTools, registerGuideTools, registerSearchTools } from './tools/index.js';
 import type { ComponentsData, CustomToolDefinition, PrimeMcpConfig, ToolResult } from './types.js';
@@ -78,21 +79,59 @@ export async function createPrimeMcpServer(config: PrimeMcpConfig): Promise<McpS
 }
 
 /**
+ * Map a custom-tool parameter type string to a Zod schema.
+ */
+function customParameterSchema(type: string): z.ZodTypeAny {
+    switch (type.toLowerCase()) {
+        case 'number':
+        case 'integer':
+        case 'float':
+            return z.number();
+        case 'boolean':
+            return z.boolean();
+        case 'array':
+            return z.array(z.unknown());
+        case 'object':
+            return z.record(z.unknown());
+        case 'string':
+        default:
+            return z.string();
+    }
+}
+
+/**
  * Register custom/framework-specific tools
  */
 function registerCustomTools(server: McpServer, data: ComponentsData, customTools: CustomToolDefinition[]): void {
     for (const tool of customTools) {
-        // Convert our parameter format to MCP's expected format
-        const params: Record<string, { type: string; description: string }> = {};
+        // Build a Zod raw shape from our lightweight parameter format. The MCP SDK
+        // (>= 1.26) validates that a tool's input schema is a Zod shape and rejects a
+        // plain `{ type, description }` object ("expected a Zod schema or
+        // ToolAnnotations, but received an unrecognized object"), so we translate it
+        // here and register through `registerTool`, matching the rest of this package.
+        const inputSchema: z.ZodRawShape = {};
 
         for (const [key, value] of Object.entries(tool.parameters)) {
-            params[key] = {
-                type: value.type,
-                description: value.description
-            };
+            let schema = customParameterSchema(value.type).describe(value.description);
+
+            if (value.default !== undefined) {
+                schema = schema.default(value.default);
+            } else if (value.required !== true) {
+                schema = schema.optional();
+            }
+
+            inputSchema[key] = schema;
         }
 
-        server.tool(tool.name, tool.description, params, async (args) => {
+        const toolConfig: { description: string; inputSchema?: z.ZodRawShape } = {
+            description: tool.description
+        };
+
+        if (Object.keys(inputSchema).length > 0) {
+            toolConfig.inputSchema = inputSchema;
+        }
+
+        server.registerTool(tool.name, toolConfig, async (args) => {
             const result = await tool.handler(data, args as Record<string, unknown>);
 
             return result as ToolResult & { [x: string]: unknown };


### PR DESCRIPTION
## Problem

`@primeng/mcp` (which depends on `@primeuix/mcp`) crashes on startup:

```
Failed to start PrimeNG MCP Server: Error: Tool get_migration_guide expected a Zod schema or ToolAnnotations, but received an unrecognized object
    at McpServer.tool (.../@modelcontextprotocol/sdk/dist/esm/server/mcp.js)
    at .../@primeuix/mcp/dist/index.js
```

Reproduced with `@modelcontextprotocol/sdk` 1.29.0. Because `@primeuix/mcp` declares `"@modelcontextprotocol/sdk": "^1.25.2"`, fresh/`npx` installs resolve the latest 1.x and hit the crash.

## Root cause

`registerCustomTools` (`packages/mcp/src/index.ts`) registers framework-specific tools through the legacy `server.tool(name, description, paramsObject, cb)` overload, passing a plain object:

```ts
const params = { version: { type: 'string', description: '...' }, /* ... */ };
server.tool(tool.name, tool.description, params, handler);
```

As of `@modelcontextprotocol/sdk` 1.26, `McpServer.tool()` validates that third argument: it must be a Zod raw shape or `ToolAnnotations`. A `{ type, description }` object is neither (its values are objects), so the SDK throws *"expected a Zod schema or ToolAnnotations, but received an unrecognized object"*. PrimeNG's `get_migration_guide` is the first custom tool registered, so that's where the crash surfaces.

Every other tool in this package already uses `server.registerTool(name, { description, inputSchema }, cb)` with a Zod shape — only `registerCustomTools` still used the old path.

## Fix

Translate the lightweight `{ type, description, required?, default? }` parameter format into a Zod raw shape and register via `registerTool`, consistent with the rest of the package:

- maps `type` → `z.string()` / `z.number()` / `z.boolean()` / `z.array(...)` / `z.record(...)`
- a parameter is `.optional()` unless `required: true`
- honors `default`

## Verification

- Reproduced the exact crash on `main` with SDK 1.29.0.
- After the fix, `createPrimeMcpServer` registers the custom tools without throwing on **both** SDK **1.29.0** and **1.25.2** (the declared floor).
- `tsup` build (ESM + `dts` type-check) passes; Prettier clean against the repo config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
